### PR TITLE
Feat/12 valuepick 기능 구현

### DIFF
--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/dao/ValuePickRepository.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/dao/ValuePickRepository.java
@@ -1,0 +1,13 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.dao;
+
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.ValuePick;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ValuePickRepository extends JpaRepository<ValuePick, Long> {
+    @Query("SELECT v FROM ValuePick v ORDER BY v.id ASC")
+    List<ValuePick> findAllValueOrdered();
+
+}

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/domain/RecommendValuePick.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/domain/RecommendValuePick.java
@@ -19,9 +19,7 @@ public class RecommendValuePick {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recommend_id", nullable = false)
-    private Recommend recommend;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "value_pick_id", nullable = false)
@@ -40,7 +38,5 @@ public class RecommendValuePick {
     }
 
 
-    public void addRecommend(Recommend recommend) {
-        this.recommend = recommend;
-    }
+
 }

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/domain/RecommendValuePick.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/domain/RecommendValuePick.java
@@ -1,0 +1,46 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+
+import java.util.List;
+
+@Entity
+@Table(name = "recommend_value_pick")
+@Getter
+@NoArgsConstructor
+public class RecommendValuePick {
+    @Id
+    @Column(name = "recommend_value_pick_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recommend_id", nullable = false)
+    private Recommend recommend;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "value_pick_id", nullable = false)
+    private ValuePick valuePick;
+
+    @Type(JsonType.class)
+    @Column(name = "selected_answers", columnDefinition = "json", nullable = false)
+    private List<Integer> selectedAnswers;
+
+
+
+    @Builder
+    public RecommendValuePick(ValuePick valuePick, List<Integer> selectedAnswers) {
+        this.valuePick = valuePick;
+        this.selectedAnswers = selectedAnswers;
+    }
+
+
+    public void addRecommend(Recommend recommend) {
+        this.recommend = recommend;
+    }
+}

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/domain/ValuePick.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/domain/ValuePick.java
@@ -1,0 +1,41 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+
+import java.util.Map;
+
+@Entity
+@Getter
+@Table(name = "value_pick")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ValuePick {
+    @Id
+    @Column(name = "value_pick_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name= "value_type")
+    private ValueType valueType;
+
+    @Column(nullable = false)
+    private String question;
+
+
+
+
+    @Type(JsonType.class)
+    @Column(name = "answers", columnDefinition = "longtext", nullable = false)
+    private Map<Integer, Object> answers;
+
+
+
+}

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/domain/ValueType.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/domain/ValueType.java
@@ -1,0 +1,5 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain;
+
+public enum ValueType {
+    CLUSTER
+}

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/dto/request/RecommendValuePickRequest.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/dto/request/RecommendValuePickRequest.java
@@ -1,0 +1,25 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "추천 문항별 사용자의 선택 응답 DTO", title = "RecommendValuePickRequest")
+public record RecommendValuePickRequest(
+        @Schema(
+                description = "문항 식별자 (ValuePick ID)",
+                example     = "1"
+        )
+        @NotNull(message = "valuePickId는 필수입니다.")
+        Long valuePickId,
+
+        @Schema(
+                description = "사용자가 선택한 보기 번호 목록",
+                example     = "[1]"
+        )
+        @NotNull(message = "selectedAnswers는 비어 있을 수 없습니다.")
+        @Size(min = 1, message = "최소 하나 이상의 답변을 선택해야 합니다.")
+        List<Integer> selectedAnswers
+) {}

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/dto/response/RecommendValuePickResponse.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/dto/response/RecommendValuePickResponse.java
@@ -1,0 +1,40 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.dto.response;
+
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.RecommendValuePick;
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.ValuePick;
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.ValueType;
+
+import java.util.List;
+
+public record RecommendValuePickResponse(
+        Long valuePickId,
+        ValueType type,
+        String question,
+        List<ValuePickAnswerResponse> answers
+) {
+    /** 옵션 조회용: ValuePick → DTO */
+    public static RecommendValuePickResponse fromValuePick(ValuePick vp) {
+        List<ValuePickAnswerResponse> answerList = vp.getAnswers().entrySet().stream()
+                .map(e -> new ValuePickAnswerResponse(e.getKey(), e.getValue().toString()))
+                .toList();
+        return new RecommendValuePickResponse(
+                vp.getId(),
+                vp.getValueType(),
+                vp.getQuestion(),
+                answerList
+        );
+    }
+
+    /** 추천 히스토리용: 실제 선택된 RecommendValuePick → DTO */
+    public static RecommendValuePickResponse fromRecommendValuePick(RecommendValuePick rvp) {
+        List<ValuePickAnswerResponse> ans = rvp.getSelectedAnswers().stream()
+                .map(i -> new ValuePickAnswerResponse(i, rvp.getValuePick().getAnswers().get(i).toString()))
+                .toList();
+        return new RecommendValuePickResponse(
+                rvp.getValuePick().getId(),
+                rvp.getValuePick().getValueType(),
+                rvp.getValuePick().getQuestion(),
+                ans
+        );
+    }
+}

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/dto/response/ValuePickAnswerResponse.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/dto/response/ValuePickAnswerResponse.java
@@ -1,0 +1,4 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.dto.response;
+
+public record ValuePickAnswerResponse(Integer number, String content) {
+}

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/service/RecommendValuePickService.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/service/RecommendValuePickService.java
@@ -1,0 +1,79 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.service;
+
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.RecommendValuePick;
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.ValuePick;
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.ValueType;
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.dto.request.RecommendValuePickRequest;
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.dto.response.RecommendValuePickResponse;
+import com.bossoverhere.capstone.boss_over_here_backend.global.error.ApplicationException;
+import com.bossoverhere.capstone.boss_over_here_backend.global.error.RecommendErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendValuePickService {
+
+    private final ValuePickService valuePickService;
+
+    /** 추천 문항 검증 */
+    @Transactional
+    public List<RecommendValuePick> createAndValidatePicks(List<RecommendValuePickRequest> reqs) {
+        // 1) 요청 ID로 DB에서 ValuePick 엔티티 조회
+        List<Long> ids = reqs.stream()
+                .map(RecommendValuePickRequest::valuePickId)
+                .toList();
+        List<ValuePick> valuePicks = valuePickService.getValuePicksByIds(ids);
+
+        // A) “문항을 한 번도 안 골랐거나 여러 개 골랐는지” 검증
+        ensureExactlyOneCluster(valuePicks);
+
+        // B) 선택 번호 유효성 검증 → 엔티티 변환
+        return reqs.stream()
+                .map(this::toRecommendValuePick)
+                .toList();
+    }
+
+    /** 추천 문항 리스트 조회 */
+    public List<RecommendValuePickResponse> getRecommendValuePickResponses() {
+        return valuePickService.getAllValuePicks().stream()
+                .map(RecommendValuePickResponse::fromValuePick)
+                .toList();
+    }
+
+    /** 클러스터 문항이 정확히 1개인지 검증 */
+    private void ensureExactlyOneCluster(List<ValuePick> valuePicks) {
+        long clusterCount = valuePicks.stream()
+                .filter(vp -> vp.getValueType() == ValueType.CLUSTER)
+                .count();
+        if (clusterCount != 1) {
+            throw new ApplicationException(RecommendErrorCode.CLUSTER_SELECTION_INVALID);
+        }
+    }
+
+    /** 하나의 요청(Request) → RecommendValuePick 엔티티로 변환 */
+    private RecommendValuePick toRecommendValuePick(RecommendValuePickRequest req) {
+        // ① ValuePick 조회
+        ValuePick vp = valuePickService.getValuePickById(req.valuePickId());
+        // ② 선택 답안 검증
+        validateAnswers(vp, req.selectedAnswers());
+        // ③ 엔티티 빌드
+        return RecommendValuePick.builder()
+                .valuePick(vp)
+                .selectedAnswers(req.selectedAnswers())
+                .build();
+    }
+
+    /** ValuePick 의 answers 키에 요청된 selectedAnswers 가 모두 포함되어 있는지 검증 */
+    private void validateAnswers(ValuePick vp, List<Integer> selectedAnswers) {
+        Set<Integer> validKeys = vp.getAnswers().keySet();
+        if (!validKeys.containsAll(selectedAnswers)) {
+            throw new ApplicationException(RecommendErrorCode.ANSWER_OPTION_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/service/ValuePickService.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/service/ValuePickService.java
@@ -1,0 +1,29 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.service;
+
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.dao.ValuePickRepository;
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.ValuePick;
+import com.bossoverhere.capstone.boss_over_here_backend.global.error.ApplicationException;
+import com.bossoverhere.capstone.boss_over_here_backend.global.error.RecommendErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ValuePickService {
+    private final ValuePickRepository valuePickRepository;
+
+    public List<ValuePick> getAllValuePicks() {
+        return valuePickRepository.findAllValueOrdered();
+    }
+
+    public List<ValuePick> getValuePicksByIds(List<Long> ids) {
+        return valuePickRepository.findAllById(ids);
+    }
+
+    public ValuePick getValuePickById(Long id) {
+        return valuePickRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(RecommendErrorCode.VALUE_PICK_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/global/error/RecommendErrorCode.java
+++ b/src/main/java/com/bossoverhere/capstone/boss_over_here_backend/global/error/RecommendErrorCode.java
@@ -1,0 +1,32 @@
+package com.bossoverhere.capstone.boss_over_here_backend.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecommendErrorCode implements ErrorCode {
+
+    // --- Not Found ---
+    RECOMMEND_NOT_FOUND(HttpStatus.NOT_FOUND, "추천 내역을 찾을 수 없습니다."),
+    VALUE_PICK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문항을 찾을 수 없습니다."),
+
+    // --- Validation Errors ---
+    QUESTION_COUNT_MISMATCH(HttpStatus.BAD_REQUEST,
+            "모든 문항에 답변해야 합니다."),  // reqs.size != questions.size()
+
+    CLUSTER_SELECTION_INVALID(HttpStatus.BAD_REQUEST,
+            "Cluster 타입은 반드시 하나만 선택해야 합니다."),
+
+    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST,"종료 시간은 시작 시간 이후여야 합니다."),
+    INVALID_DATE(HttpStatus.BAD_REQUEST,"과거 날짜는 선택할 수 없습니다."),
+
+    ANSWER_OPTION_INVALID(HttpStatus.BAD_REQUEST,
+            "유효하지 않은 선택지 번호입니다."),;
+
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,0 +1,2 @@
+INSERT INTO value_pick (value_pick_id, value_type, question, answers) VALUES
+    (1, 'CLUSTER', '판매하는 음식을 선택해주세요', '{"1":"떡볶이,파스타","2":"닭꼬치,핫도그","3":"김밥,라면","4":"치킨,피자","5":"커피,주스"}');

--- a/src/test/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/service/RecommendValuePickServiceTest.java
+++ b/src/test/java/com/bossoverhere/capstone/boss_over_here_backend/domain/valuepick/service/RecommendValuePickServiceTest.java
@@ -1,0 +1,110 @@
+package com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.service;
+
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.ValuePick;
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.domain.ValueType;
+import com.bossoverhere.capstone.boss_over_here_backend.domain.valuepick.dto.request.RecommendValuePickRequest;
+import com.bossoverhere.capstone.boss_over_here_backend.global.error.ApplicationException;
+import com.bossoverhere.capstone.boss_over_here_backend.global.error.RecommendErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendValuePickServiceTest {
+
+    @InjectMocks
+    RecommendValuePickService service;
+
+    @Mock
+    ValuePickService valuePickService;
+
+    // 헬퍼: Map 형태의 답안 가진 ValuePick 목 생성
+    // 변경 후
+    private ValuePick makeVp(ValueType type, Integer... keys) {
+        ValuePick vp = mock(ValuePick.class);
+        when(vp.getValueType()).thenReturn(type);
+        Map<Integer,Object> answers = new HashMap<>();
+        for (Integer k : keys) answers.put(k, "A"+k);
+        when(vp.getAnswers()).thenReturn(answers);
+        return vp;
+    }
+
+    @Test
+    @DisplayName("정상: 정확히 1개 CLUSTER, 유효 답안")
+    void valid_singleCluster() {
+        // 요청도 1개
+        var reqs = List.of(new RecommendValuePickRequest(1L, List.of(1)));
+        // DB 에도 1개 CLUSTER
+        var vps = List.of(makeVp( ValueType.CLUSTER, 1));
+        when(valuePickService.getValuePicksByIds(any())).thenReturn(vps);
+        // 세부 조회도 stub
+        when(valuePickService.getValuePickById(1L)).thenReturn(vps.get(0));
+
+        var picks = service.createAndValidatePicks(reqs);
+        assertThat(picks).hasSize(1);
+        assertThat(picks.get(0).getValuePick()).isEqualTo(vps.get(0));
+        assertThat(picks.get(0).getSelectedAnswers()).containsExactly(1);
+    }
+
+    @Test @DisplayName("실패: CLUSTER 0개 → CLUSTER_SELECTION_INVALID")
+    void noCluster_throws() {
+        var reqs = List.of(new RecommendValuePickRequest(1L, List.of(1)));
+        when(valuePickService.getValuePicksByIds(any())).thenReturn(List.of());
+        assertThatThrownBy(() -> service.createAndValidatePicks(reqs))
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCode")
+                .isEqualTo(RecommendErrorCode.CLUSTER_SELECTION_INVALID);
+    }
+
+    private ValuePick makeTypeOnlyVp(ValueType type) {
+        ValuePick vp = mock(ValuePick.class);
+        when(vp.getValueType()).thenReturn(type);
+        return vp;
+    }
+
+    @Test @DisplayName("실패: CLUSTER 2개 → CLUSTER_SELECTION_INVALID")
+    void multipleCluster_throws() {
+        var reqs = List.of(
+                new RecommendValuePickRequest(1L, List.of(1)),
+                new RecommendValuePickRequest(2L, List.of(1))
+        );
+        // 타입만 stub
+        var vps = List.of(
+                makeTypeOnlyVp(ValueType.CLUSTER),
+                makeTypeOnlyVp(ValueType.CLUSTER)
+        );
+        when(valuePickService.getValuePicksByIds(any())).thenReturn(vps);
+
+        assertThatThrownBy(() -> service.createAndValidatePicks(reqs))
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCode")
+                .isEqualTo(RecommendErrorCode.CLUSTER_SELECTION_INVALID);
+    }
+
+    @Test @DisplayName("실패: 선택 답안에 유효하지 않은 번호 포함 → ANSWER_OPTION_INVALID")
+    void invalidAnswer_throws() {
+        var reqs = List.of(new RecommendValuePickRequest(1L, List.of(99)));
+        var vp = makeVp(ValueType.CLUSTER, 1,2);
+        when(valuePickService.getValuePicksByIds(any())).thenReturn(List.of(vp));
+        when(valuePickService.getValuePickById(1L)).thenReturn(vp);
+
+        assertThatThrownBy(() -> service.createAndValidatePicks(reqs))
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCode")
+                .isEqualTo(RecommendErrorCode.ANSWER_OPTION_INVALID);
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

- ValuePick 엔티티, Repository, Service 구현
- RecommendValuePickService (문항 검증 및 DTO 변환) 구현
- DTO(Request/Response) 정의
- “추천 옵션 조회”용 API(stub 컨트롤러) 및 테스트

## ➕ 추가/변경된 기능

1. `ValuePick`/`RecommendValuePick` 엔티티, Repository 작성  
2. `ValuePickService` → `getAllValuePicks()`, `getById()` 구현  
3. `RecommendValuePickService#createAndValidatePicks()` 구현  
4. `RecommendValuePickRequest`/`RecommendValuePickResponse` DTO 작성  
5. `/api/recommend/options` API 스텁 및 CommonResponse 래핑  
6. 단위 테스트: 서비스 레이어

## 🗎 관련 이슈

#12 
